### PR TITLE
Reset the console colour after printing the list of commands

### DIFF
--- a/src/Fargo/Fargo.fs
+++ b/src/Fargo/Fargo.fs
@@ -598,6 +598,7 @@ module Run =
                         | Some alt -> name + ", " + alt
                     printfn $"    %-24s{cmd}%s{c.Description}"
                 | None -> ()
+            printfn $"%s{Colors.def}"
 
         match args with
         | [] -> ()


### PR DESCRIPTION
When doing some testing I noticed that when I ran my test app with no command specified, it printed an error message in red, then the list of commands in yellow, and then left the terminal colour set to yellow.

I think it should be setting it back to default, as it does after printing the lists of arguments and options?