### PR TITLE
Name the arguments to the 'flag' function in Fargo.fsi

### DIFF
--- a/src/Fargo/Fargo.fsi
+++ b/src/Fargo/Fargo.fsi
@@ -77,7 +77,7 @@ module Fargo =
     val reqArg: Arg<'a option> -> Arg<'a>
 
     /// A flag parser. Flags are matched by name and are optional by default. Value is false when not specified
-    val flag: string -> string -> string -> Arg<bool>
+    val flag: name:string -> alt:string -> description:string -> Arg<bool>
 
     /// Make a flag required.
     val reqFlag: Arg<bool> -> Arg<bool>


### PR DESCRIPTION
As it stands, the visual studio tooltip for ```flag``` isn't very useful - 

![image](https://github.com/thinkbeforecoding/Fargo/assets/1178570/7e33071d-1f06-4955-a535-14dd355ab04b)

And I think that adding names in a similar way to is already done for ```opt``` would make it better?

![image](https://github.com/thinkbeforecoding/Fargo/assets/1178570/eab17576-74b7-40c2-9384-72485636c691)
